### PR TITLE
chore(spec): add fallback behavior for external dependencies (CHK014)

### DIFF
--- a/specs/001-add-prd/checklists/track_issues.md
+++ b/specs/001-add-prd/checklists/track_issues.md
@@ -1,0 +1,16 @@
+```markdown
+# Checklist Issue Tracking
+
+This file records the epic issues created to track open checklist items for the PRD feature.
+
+- Epic for `requirements.md`: https://github.com/EvertonKaylon/coreano-marcial/issues/5
+- Epic for `requirements-prd-20260202.md`: https://github.com/EvertonKaylon/coreano-marcial/issues/6
+
+Individual gap issues created earlier:
+- CHK012: https://github.com/EvertonKaylon/coreano-marcial/issues/2
+- CHK014: https://github.com/EvertonKaylon/coreano-marcial/issues/3
+- CHK016: https://github.com/EvertonKaylon/coreano-marcial/issues/4
+
+Use the epic issues to track and close checklist items. When an item is completed, update the checklist file and close the corresponding task in the epic.
+
+```


### PR DESCRIPTION
Addresses CHK014 from checklist. See https://github.com/EvertonKaylon/coreano-marcial/issues/3. Adds draft fallback behavior for external dependencies to specs/001-add-prd/spec.md.