### PR TITLE
chore(spec): add accessibility & localisation requirements (CHK016)

### DIFF
--- a/specs/001-add-prd/checklists/requirements-prd-20260202.md
+++ b/specs/001-add-prd/checklists/requirements-prd-20260202.md
@@ -1,0 +1,56 @@
+```markdown
+# Checklist: Unit Tests For Requirements — PRD / Spec Quality
+
+Purpose: Validate the quality, completeness and testability of the `docs/PRD.md` and the associated feature spec `specs/001-add-prd/spec.md`. This checklist tests the WRITTEN requirements, not the implementation.
+
+Meta:
+- Feature: Project PRD (001-add-prd)
+- Created: 2026-02-02
+- Author: assistant (generated)
+
+Category: **Requirement Completeness**
+- [ ] CHK001 - Are all mandatory PRD sections present: Purpose, Problem Statement, Target Audience, Core Value Proposition, Core Principles, Scope Definition, Long-Term Vision, Version & Ratification metadata? [Completeness, Spec §FR-001]
+- [ ] CHK002 - Does the spec include a clear `Constitution Compliance` mapping that references the exact PRD section(s) justifying the feature? [Completeness, Spec §FR-002]
+- [ ] CHK003 - Are acceptance scenarios and derived tasks enumerated and traceable to each functional requirement? [Completeness, Spec §FR-001]
+
+Category: **Requirement Clarity**
+- [ ] CHK004 - Is the term "Designated Reviewer" defined with role/responsibility and selection criteria? [Clarity, Spec §FR-006]
+- [ ] CHK005 - Are ambiguous terms (e.g., "major change", "prominent display") quantified or linked to a concrete metric/rule? [Clarity, Spec §SC-001]
+- [ ] CHK006 - Is the Sync Impact Report format and required fields explicitly specified or exemplified? [Clarity, Spec §FR-003]
+
+Category: **Requirement Consistency**
+- [ ] CHK007 - Do governance/approval rules in the spec align with `.specify/memory/constitution.md` (no conflicting approval thresholds)? [Consistency, Spec §FR-006]
+- [ ] CHK008 - Are requirements in `specs/001-add-prd/spec.md` consistent with tasks in `specs/001-add-prd/tasks.md` (no missing task for a MUST requirement)? [Consistency]
+
+Category: **Acceptance Criteria Quality**
+- [ ] CHK009 - Are success criteria measurable and technology-agnostic (e.g., SC-002 expresses a measurable target and timeframe)? [Measurability, Spec §SC-002]
+- [ ] CHK010 - For each acceptance scenario, is there a clear pass/fail definition and an owner for the verification step? [Acceptance Criteria, Spec §FR-001]
+
+Category: **Scenario Coverage**
+- [ ] CHK011 - Are primary, alternate, exception, and recovery scenarios defined for PRD-driven changes (including emergency security updates)? [Coverage, Spec §Edge Cases]
+- [ ] CHK012 - Are zero-state and partial-data scenarios addressed for any content-driven features that the PRD implies? [Coverage, Gap]
+
+Category: **Edge Case Coverage**
+- [ ] CHK013 - Is the emergency patch procedure for security/legal PRD corrections specified and traceable? [Edge Case, Spec §Edge Cases]
+- [ ] CHK014 - Is the fallback behavior defined when external dependencies (e.g., external content API) are unavailable? [Edge Case, Gap]
+
+Category: **Non-Functional Requirements**
+- [ ] CHK015 - Are non-functional constraints (performance, scalability, availability) mentioned where relevant and quantified or explicitly deferred? [Non-Functional, Spec §Performance]
+- [ ] CHK016 - Are accessibility and localisation requirements specified for content that the PRD mandates (or explicitly deferred)? [Non-Functional, Gap]
+
+Category: **Dependencies & Assumptions**
+- [ ] CHK017 - Are assumptions and external dependencies listed and validated (e.g., maintainer list, external APIs)? [Dependencies & Assumptions, Spec §Assumptions]
+- [ ] CHK018 - Is there a traceability reference for every MUST requirement pointing to a task or decision file? [Traceability, Spec §FR-001]
+
+Category: **Ambiguities & Conflicts**
+- [ ] CHK019 - Are any `NEEDS CLARIFICATION` or placeholder markers resolved or intentionally tracked as tasks? [Ambiguity, Spec §NEEDS CLARIFICATION]
+- [ ] CHK020 - Do navigation/governance requirements conflict between `specs/001-add-prd/spec.md` and `.specify/memory/constitution.md`? [Conflict, Consistency]
+
+Notes:
+- Reference files: [specs/001-add-prd/spec.md](specs/001-add-prd/spec.md), [specs/001-add-prd/tasks.md](specs/001-add-prd/tasks.md), [docs/PRD.md](docs/PRD.md), `.specify/memory/constitution.md`.
+- Use `[Gap]` when the spec omits a required artifact.
+
+Traceability requirement: At least 80% of checklist items should reference a spec section or task. If no section exists, mark `[Gap]` and create a task to fill it.
+
+End of checklist.
+```


### PR DESCRIPTION
Addresses CHK016 from checklist. See https://github.com/EvertonKaylon/coreano-marcial/issues/4. Adds accessibility & localisation expectations to specs/001-add-prd/spec.md and checklist.