### PR TITLE
ci: add security-scan

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS: define repository owners for code review and ownership
+# Pattern: all files -> project owner
+* @EvertonKaylon

--- a/.github/scripts/validate_prd.py
+++ b/.github/scripts/validate_prd.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Validate presence of PRD and basic Constitution compliance in changed specs."""
+import sys
+from pathlib import Path
+
+
+def fail(msg: str):
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+repo_root = Path(__file__).resolve().parents[2]
+prd = repo_root / "docs" / "PRD.md"
+constitution = repo_root / ".specify" / "memory" / "constitution.md"
+
+if not prd.exists():
+    fail("docs/PRD.md not found in repo")
+
+if not constitution.exists():
+    fail(".specify/memory/constitution.md not found in repo")
+
+content = prd.read_text(encoding="utf8")
+if "Constitution" not in content and "Constitution Compliance" not in content:
+    # be permissive but fail if no hint of Constitution mention
+    fail("docs/PRD.md does not mention 'Constitution' or 'Constitution Compliance'")
+
+print("PRD and Constitution files present and PRD mentions Constitution (basic check)")
+sys.exit(0)

--- a/.github/workflows/prd-guards.yml
+++ b/.github/workflows/prd-guards.yml
@@ -32,3 +32,25 @@ jobs:
             done
             if [ "$missing" -eq 1 ]; then exit 1; fi
           fi
+  lint-and-validate:
+    runs-on: ubuntu-latest
+    needs: check-prd-meta
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ruff black
+      - name: Ruff check
+        run: |
+          ruff check . || (echo 'ruff found issues' && exit 1)
+      - name: Black check
+        run: |
+          python -m black --check . || (echo 'black formatting issues' && exit 1)
+      - name: Validate PRD and Constitution Compliance
+        run: |
+          python .github/scripts/validate_prd.py

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,32 @@
+name: Security Scan
+
+on:
+  pull_request:
+    paths:
+      - '**/*.py'
+      - 'requirements.txt'
+
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install bandit safety
+      - name: Run bandit
+        run: |
+          bandit -r . -x .venv,.git -lll || { echo 'bandit issues found' ; exit 1; }
+      - name: Run safety (requirements)
+        run: |
+          if [ -f requirements.txt ]; then
+            python -m pip install -r requirements.txt >/dev/null 2>&1 || true
+            safety check -r requirements.txt || { echo 'safety found issues' ; exit 1; }
+          else
+            echo 'no requirements.txt, skipping safety'
+          fi

--- a/specs/001-add-prd/checklists/requirements-prd-20260202.md
+++ b/specs/001-add-prd/checklists/requirements-prd-20260202.md
@@ -1,0 +1,56 @@
+```markdown
+# Checklist: Unit Tests For Requirements — PRD / Spec Quality
+
+Purpose: Validate the quality, completeness and testability of the `docs/PRD.md` and the associated feature spec `specs/001-add-prd/spec.md`. This checklist tests the WRITTEN requirements, not the implementation.
+
+Meta:
+- Feature: Project PRD (001-add-prd)
+- Created: 2026-02-02
+- Author: assistant (generated)
+
+Category: **Requirement Completeness**
+- [ ] CHK001 - Are all mandatory PRD sections present: Purpose, Problem Statement, Target Audience, Core Value Proposition, Core Principles, Scope Definition, Long-Term Vision, Version & Ratification metadata? [Completeness, Spec §FR-001]
+- [ ] CHK002 - Does the spec include a clear `Constitution Compliance` mapping that references the exact PRD section(s) justifying the feature? [Completeness, Spec §FR-002]
+- [ ] CHK003 - Are acceptance scenarios and derived tasks enumerated and traceable to each functional requirement? [Completeness, Spec §FR-001]
+
+Category: **Requirement Clarity**
+- [ ] CHK004 - Is the term "Designated Reviewer" defined with role/responsibility and selection criteria? [Clarity, Spec §FR-006]
+- [ ] CHK005 - Are ambiguous terms (e.g., "major change", "prominent display") quantified or linked to a concrete metric/rule? [Clarity, Spec §SC-001]
+- [ ] CHK006 - Is the Sync Impact Report format and required fields explicitly specified or exemplified? [Clarity, Spec §FR-003]
+
+Category: **Requirement Consistency**
+- [ ] CHK007 - Do governance/approval rules in the spec align with `.specify/memory/constitution.md` (no conflicting approval thresholds)? [Consistency, Spec §FR-006]
+- [ ] CHK008 - Are requirements in `specs/001-add-prd/spec.md` consistent with tasks in `specs/001-add-prd/tasks.md` (no missing task for a MUST requirement)? [Consistency]
+
+Category: **Acceptance Criteria Quality**
+- [ ] CHK009 - Are success criteria measurable and technology-agnostic (e.g., SC-002 expresses a measurable target and timeframe)? [Measurability, Spec §SC-002]
+- [ ] CHK010 - For each acceptance scenario, is there a clear pass/fail definition and an owner for the verification step? [Acceptance Criteria, Spec §FR-001]
+
+Category: **Scenario Coverage**
+- [ ] CHK011 - Are primary, alternate, exception, and recovery scenarios defined for PRD-driven changes (including emergency security updates)? [Coverage, Spec §Edge Cases]
+- [ ] CHK012 - Are zero-state and partial-data scenarios addressed for any content-driven features that the PRD implies? [Coverage, Gap]
+
+Category: **Edge Case Coverage**
+- [ ] CHK013 - Is the emergency patch procedure for security/legal PRD corrections specified and traceable? [Edge Case, Spec §Edge Cases]
+- [ ] CHK014 - Is the fallback behavior defined when external dependencies (e.g., external content API) are unavailable? [Edge Case, Gap]
+
+Category: **Non-Functional Requirements**
+- [ ] CHK015 - Are non-functional constraints (performance, scalability, availability) mentioned where relevant and quantified or explicitly deferred? [Non-Functional, Spec §Performance]
+- [ ] CHK016 - Are accessibility and localisation requirements specified for content that the PRD mandates (or explicitly deferred)? [Non-Functional, Gap]
+
+Category: **Dependencies & Assumptions**
+- [ ] CHK017 - Are assumptions and external dependencies listed and validated (e.g., maintainer list, external APIs)? [Dependencies & Assumptions, Spec §Assumptions]
+- [ ] CHK018 - Is there a traceability reference for every MUST requirement pointing to a task or decision file? [Traceability, Spec §FR-001]
+
+Category: **Ambiguities & Conflicts**
+- [ ] CHK019 - Are any `NEEDS CLARIFICATION` or placeholder markers resolved or intentionally tracked as tasks? [Ambiguity, Spec §NEEDS CLARIFICATION]
+- [ ] CHK020 - Do navigation/governance requirements conflict between `specs/001-add-prd/spec.md` and `.specify/memory/constitution.md`? [Conflict, Consistency]
+
+Notes:
+- Reference files: [specs/001-add-prd/spec.md](specs/001-add-prd/spec.md), [specs/001-add-prd/tasks.md](specs/001-add-prd/tasks.md), [docs/PRD.md](docs/PRD.md), `.specify/memory/constitution.md`.
+- Use `[Gap]` when the spec omits a required artifact.
+
+Traceability requirement: At least 80% of checklist items should reference a spec section or task. If no section exists, mark `[Gap]` and create a task to fill it.
+
+End of checklist.
+```


### PR DESCRIPTION
Add security scanning workflow (bandit + safety) for PRs touching Python files or requirements.